### PR TITLE
Develop

### DIFF
--- a/sofrimento/src/main/java/br/edu/utfpr/sofrimento/models/Silo.java
+++ b/sofrimento/src/main/java/br/edu/utfpr/sofrimento/models/Silo.java
@@ -1,5 +1,6 @@
 package br.edu.utfpr.sofrimento.models;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -12,5 +13,6 @@ import lombok.ToString;
 @Entity     //Indica que é uma entidade a ser preservada no database
 @Table(name="tb_silo") //Nome da tabela
 public class Silo extends BaseEntity{
+    @Column(name = "physical_id", nullable=false)
     private Integer physicalId;
 }

--- a/sofrimento/src/main/java/br/edu/utfpr/sofrimento/models/Silo.java
+++ b/sofrimento/src/main/java/br/edu/utfpr/sofrimento/models/Silo.java
@@ -1,0 +1,16 @@
+package br.edu.utfpr.sofrimento.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter // Em cima da classe, cria os get e set automaticamente
+@Setter
+@ToString
+@Entity     //Indica que é uma entidade a ser preservada no database
+@Table(name="tb_silo") //Nome da tabela
+public class Silo extends BaseEntity{
+    private Integer physicalId;
+}

--- a/sofrimento/src/main/java/br/edu/utfpr/sofrimento/repositories/SiloRepository.java
+++ b/sofrimento/src/main/java/br/edu/utfpr/sofrimento/repositories/SiloRepository.java
@@ -1,0 +1,11 @@
+package br.edu.utfpr.sofrimento.repositories;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import br.edu.utfpr.sofrimento.models.Silo;
+
+public interface SiloRepository extends JpaRepository<Silo, UUID> {
+    // Obter?
+}

--- a/sofrimento/src/main/resources/application.properties
+++ b/sofrimento/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=appaula
+spring.application.name=sofrimento
 
 
 # Configurações de conexão com o PostgreSQL (Neon Database)

--- a/sofrimento/src/main/resources/application.properties
+++ b/sofrimento/src/main/resources/application.properties
@@ -1,1 +1,27 @@
-spring.application.name=sofrimento
+spring.application.name=appaula
+
+
+# Configurações de conexão com o PostgreSQL (Neon Database)
+spring.datasource.url=jdbc:postgresql://ep-long-mud-ac5j56oh-pooler.sa-east-1.aws.neon.tech/neondb?user=neondb_owner&password=npg_7viSwKeu3XEV&sslmode=require&channelBinding=require
+spring.datasource.username=neondb_owner
+spring.datasource.password=npg_7viSwKeu3XEV
+
+# Driver JDBC
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# Dialeto do Banco de dados
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+#spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.postgis.PostgisDialect
+
+# Outras configurações
+# none para não recriar as tabelas toda vez que reiniciar a aplicação
+# create para fazer tudo toda vez
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+
+spring.sql.init.mode=always
+spring.sql.init.platform=postgresql
+
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+
+spring.jpa.open-in-view=false


### PR DESCRIPTION
## Summary by Sourcery

Configure Neon PostgreSQL datasource with JPA settings and introduce a Silo entity along with its repository.

New Features:
- Add PostgreSQL (Neon) datasource configuration and JPA properties for automatic schema creation and SQL initialization
- Introduce Silo JPA entity mapped to the tb_silo table with a physicalId field
- Add SiloRepository interface extending JpaRepository for CRUD operations on Silo entities