### PR TITLE
feat: controller, service e repository de property criados

### DIFF
--- a/sofrimento/src/main/java/br/edu/utfpr/sofrimento/controllers/PropertyController.java
+++ b/sofrimento/src/main/java/br/edu/utfpr/sofrimento/controllers/PropertyController.java
@@ -1,5 +1,82 @@
 package br.edu.utfpr.sofrimento.controllers;
 
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.edu.utfpr.sofrimento.dtos.PropertyDTO;
+import br.edu.utfpr.sofrimento.models.Property;
+import br.edu.utfpr.sofrimento.services.PropertyService;
+
+@RestController
+@RequestMapping("/property")
 public class PropertyController {
 
+    private final PropertyService service;
+
+    public PropertyController(PropertyService service) {
+        this.service = service;
+    }
+
+    //CREATE
+    @PostMapping(value = {"", "/"})
+    public PropertyDTO create(@PathVariable String personId, @RequestBody PropertyDTO dto) {
+        return service.save(personId, dto);
+    }
+
+    //GET ALL
+    @GetMapping(value = {"", "/"})
+    public Page<PropertyDTO> listAll(
+            @RequestParam String personId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+            if (personId == null)     
+                return service.listAll(page, size);
+            else 
+                return service.listByPerson(personId, page, size);
+    }
+
+    //GET BY ID
+    @GetMapping(value = {"/{propertyId}","/{propertyId}/"})
+    public Property findById(
+            @PathVariable String propertyId) {
+        return service.findById(propertyId);
+    }
+
+    //GET BY PERSON ID
+    @GetMapping(value = {"/person","/person"})
+    public Page<PropertyDTO> listByPerson(
+            @RequestParam String personId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return service.listByPerson(personId, page, size);
+    }
+
+    // DELETE
+    @DeleteMapping(value = {"/{propertyId}","/{propertyId}/"})
+    public void delete(@PathVariable String id) {
+        service.delete(id);
+    }
+
+    /**
+     * Endpoint para atualizar uma person existente.
+     * Recebe o ID da person como parâmetro de caminho e um objeto PersonDTO no
+     * corpo da requisição.
+     * Retorna a person atualizada.
+     * 
+     * @param id
+     * @param dto
+     * @return
+     */
+    @PutMapping(value = {"/{propertyId}","/{propertyId}/"})
+    public Property update(@PathVariable String id, @RequestBody PropertyDTO dto) {
+        return service.update(id, dto);
+    }
 }

--- a/sofrimento/src/main/java/br/edu/utfpr/sofrimento/repositories/PropertyRepository.java
+++ b/sofrimento/src/main/java/br/edu/utfpr/sofrimento/repositories/PropertyRepository.java
@@ -2,10 +2,12 @@ package br.edu.utfpr.sofrimento.repositories;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import br.edu.utfpr.sofrimento.models.Property;
 
 public interface PropertyRepository extends JpaRepository<Property, UUID>{
-
+    Page<Property> findByPersonId(UUID personId, Pageable pageable);
 }

--- a/sofrimento/src/main/java/br/edu/utfpr/sofrimento/services/PropertyService.java
+++ b/sofrimento/src/main/java/br/edu/utfpr/sofrimento/services/PropertyService.java
@@ -1,0 +1,92 @@
+package br.edu.utfpr.sofrimento.services;
+
+import java.util.UUID;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import br.edu.utfpr.sofrimento.dtos.PropertyDTO;
+import br.edu.utfpr.sofrimento.exception.NotFoundException;
+import br.edu.utfpr.sofrimento.models.Person;
+import br.edu.utfpr.sofrimento.models.Property;
+import br.edu.utfpr.sofrimento.repositories.PersonRepository;
+import br.edu.utfpr.sofrimento.repositories.PropertyRepository;
+
+public class PropertyService {
+    private final PropertyRepository propertyRepo;
+    private final PersonRepository personRepo;
+
+    public PropertyService(PropertyRepository propertyRepo, PersonRepository personRepo) {
+        this.propertyRepo = propertyRepo;
+        this.personRepo = personRepo;
+    }
+
+    //CREATE
+    public PropertyDTO save(String personId, PropertyDTO propertyDTO) {
+        Person person = personRepo.findById(UUID.fromString(personId))
+                .orElseThrow(() -> new NotFoundException("Person " + personId + " não encontrada."));
+
+        Property property = new Property(); // Cria um property vazio
+        BeanUtils.copyProperties(propertyDTO, property, "id"); // Copia as propriedades do DTO para o property
+        property.setPerson(person); // Associando a person ao novo property
+        
+        Property saved = propertyRepo.save(property);
+        return new PropertyDTO(saved.getId(), saved.getName());
+    }
+
+    //READ BY PERSON
+    public Page<PropertyDTO> listByPerson(String personId, int page, int size) {
+        return propertyRepo.findByPersonId(UUID.fromString(personId), PageRequest.of(page, size))
+                .map(l -> new PropertyDTO(l.getId(), l.getName()));
+    }
+
+    /**
+     * //READ BY ID
+     * 
+     * @param id
+     * @return
+     */
+    public Property findById(String id) {
+        return propertyRepo.findById(UUID.fromString(id))
+                .orElseThrow(() -> new NotFoundException("Property não encontrada com ID: " + id));
+    }
+
+    /**
+     * //READ ALL
+     * 
+     * @param page
+     * @param size
+     * @return
+     */
+    public Page<PropertyDTO> listAll(int page, int size) {
+        return propertyRepo.findAll(PageRequest.of(page, size)).map(l -> new PropertyDTO(l.getId(), l.getName()));
+    }
+
+    /**
+     * DELETE BY ID
+     * 
+     * @param id
+     */
+    public void delete(String id) {
+        //logger.info("Deletando property com ID: " + id);
+        propertyRepo.delete(findById(id));
+    }
+
+    /**
+     * UPDATE BY ID
+     * Converte um objeto PersonDTO para a entidade Person e a atualiza.
+     * 
+     * @param id
+     * @param propertyDTO
+     * @return
+     */
+    public Property update(String id, PropertyDTO propertyDTO) {
+        var existingProperty = findById(id);
+        BeanUtils.copyProperties(propertyDTO, existingProperty, "id");
+
+        //logger.info("Atualizando person: " + existingPerson);
+
+        return propertyRepo.save(existingProperty);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce CRUD support for Property entity by adding a REST controller, service layer, and repository with pagination support

New Features:
- Add PropertyController with endpoints for creating, fetching (all, by ID, and by person), updating, and deleting properties
- Implement PropertyService to handle property creation, retrieval, update, deletion, and listing with business logic validations
- Define PropertyRepository extending JpaRepository with custom findByPersonId method for paginated queries