### PR TITLE
Feat: Adicionado base do Swagger.

### DIFF
--- a/sofrimento/pom.xml
+++ b/sofrimento/pom.xml
@@ -80,7 +80,12 @@
 			<version>4.5.0</version>
 		</dependency>
 
-		
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
+
 		<!-- <dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>

--- a/sofrimento/src/main/java/br/edu/utfpr/sofrimento/openapi/OpenAPIConfiguration.java
+++ b/sofrimento/src/main/java/br/edu/utfpr/sofrimento/openapi/OpenAPIConfiguration.java
@@ -1,0 +1,48 @@
+package br.edu.utfpr.sofrimento.openapi;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+@Configuration
+
+// Configurações gerais da API
+@OpenAPIDefinition(
+  info =@Info(
+    title = "Lembretes API",
+    version = "${api.version}",
+    contact = @Contact(
+      name = "Bernard Moreno, João Vitor dos Gomes Santos, Laerte Menegol Ledur, Marcos Vinícius Ribeiro da Silva", email = "Vários", url = "https://portal.utfpr.edu.br"
+    ),
+    license = @License(
+      name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0"
+    ),
+    //termsOfService = "${tos.uri}",
+    description = "${api.description}"
+  ),
+  servers = {
+    @Server(
+      url = "${api.server.dev}",
+      description = "Development"
+    ),
+    @Server(
+      url = "${api.server.prod}",
+      description = "Production"
+    ),
+  }
+)
+
+// Configurações de autenticação
+@SecurityScheme(
+  name = "Authorization",
+  type = SecuritySchemeType.HTTP,
+  bearerFormat = "JWT",
+  scheme = "bearer"
+)
+public class OpenAPIConfiguration {}

--- a/sofrimento/src/main/resources/application.properties
+++ b/sofrimento/src/main/resources/application.properties
@@ -31,3 +31,10 @@ aws.cognito.url=https://cognito-idp.us-east-2.amazonaws.com
 aws.cognito.userPoolId=us-east-2_4gsEUSZkk
 aws.cognito.clientId=1m7jmbevcc0tanlm8qlfgfc83d
 aws.cognito.clientSecret=1c4lhhvdfnk3vmekeivgk3p78hlqrhranhncapq9i05b3oo075cd
+
+springdoc.packages-to-scan=br.edu.utfpr.sofrimento.controllers
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/index.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.filter=true


### PR DESCRIPTION
## Summary by Sourcery

Integrate Swagger/OpenAPI support using springdoc-openapi by adding the necessary dependency, configuration class, and application property settings for UI and documentation endpoints.

New Features:
- Add OpenAPIConfiguration class to define API metadata, server environments, and JWT security scheme.

Enhancements:
- Configure Swagger UI and API docs paths, package scanning, and operation/tag sorting in application.properties.

Build:
- Add springdoc-openapi-starter-webmvc-ui dependency in pom.xml for Swagger UI integration.